### PR TITLE
Fix Python YAML validation CSafeLoader errors

### DIFF
--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -17,6 +17,8 @@ jobs:
       run: git submodule update --init
     - name: Pull engine updates
       uses: space-wizards/submodule-dependency@v0.1.5
+    - name: Install PyYAML with C extensions
+      run: pip install pyyaml==6.0.2
     - uses: PaulRitter/yaml-schema-validator@v1
       with:
         schema: RobustToolbox/Schemas/rga.yml

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -17,6 +17,8 @@ jobs:
       run: git submodule update --init
     - name: Pull engine updates
       uses: space-wizards/submodule-dependency@v0.1.5
+    - name: Install PyYAML with C extensions
+      run: pip install pyyaml==6.0.2
     - uses: PaulRitter/yaml-schema-validator@v1
       with:
         schema: RobustToolbox/Schemas/mapfile.yml


### PR DESCRIPTION
## About the PR
Fixed GitHub Actions Python validation failures caused by PyYAML CSafeLoader AttributeError. Added PyYAML 6.0.2 installation step before schema validators to ensure C extensions are available.

## Why / Balance
This is a CI/CD infrastructure fix that resolves failing GitHub Actions workflows. The Map file schema validator and RGA schema validator were failing with `AttributeError: module 'yaml' has no attribute 'CSafeLoader'` because PyYAML 6.0.3 was being installed from source without C extensions.

## Technical details
- Added `pip install pyyaml==6.0.2` step before `PaulRitter/yaml-schema-validator@v1` in both workflows

## Media
N/A - Infrastructure/CI fix only

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None - CI/CD workflow changes only

**Changelog**
<!-- No gameplay changes -->